### PR TITLE
Ignore notification 'rescript/compilationFinished'

### DIFF
--- a/lsp-rescript.el
+++ b/lsp-rescript.el
@@ -108,7 +108,8 @@ representation of LSP request JSON data."
  (make-lsp-client
   :new-connection (lsp-stdio-connection (lambda () lsp-rescript-server-command))
   :major-modes '(rescript-mode)
-  :notification-handlers (ht ("client/registerCapability" #'ignore))
+  :notification-handlers (ht ("client/registerCapability" #'ignore)
+                             ("rescript/compilationFinished" #'ignore))
   :request-handlers (ht("window/showMessageRequest"
                         #'lsp-rescript--handle-show-message-request))
   :priority 1


### PR DESCRIPTION
As of version '1.2.1' of the rescript LSP server, it sends a message
'rescript/compilationFinished' to the client; which then runs dead-code
detection using 'npx' [1].

We simply ignore the message.

[1]: https://bit.ly/rescript-dead-code-l214