### PR TITLE
Support for additional lsp commands

### DIFF
--- a/lsp-rescript.el
+++ b/lsp-rescript.el
@@ -89,12 +89,12 @@ representation of LSP request JSON data."
   ;; client.  This sends back all of the parameters instead of only `title' as
   ;; vanilla lsp-mode.el does.
   (let* ((message (lsp-rescript--propertize message type))
-          (choices (--map (gethash "title" it) actions?)))
+         (choices (--map (gethash "title" it) actions?)))
     (if choices
         (let* ((selected (completing-read (concat message " ") choices nil t))
                (ht (car (--filter (equal (gethash "title" it) selected)
                                   (append actions? nil))))
-                (response (lsp-rescript--symbolize-json ht)))
+               (response (lsp-rescript--symbolize-json ht)))
           response)
       (lsp-log message))))
 
@@ -102,6 +102,21 @@ representation of LSP request JSON data."
   "Handle a show message REQUEST in lsp WORKSPACE."
   (if lsp-rescript-prompt-for-build
       (lsp-rescript--window-log-message-request request)))
+
+
+;; More Rescript utility functions
+(defun lsp-rescript--create-interface-from-buffer (buffer)
+  (interactive "bFile containing implementation: ")
+  (with-current-buffer buffer
+    (let ((uri (concat "file://localhost" (buffer-file-name) )))
+      (if (lsp-request "textDocument/createInterface"
+                       (list
+                        :uri uri)
+                       )
+          (find-file (concat (buffer-file-name) "i" ))
+        ())
+      )))
+
 
 (add-to-list 'lsp-language-id-configuration '(rescript-mode . "rescript"))
 (lsp-register-client

--- a/lsp-rescript.el
+++ b/lsp-rescript.el
@@ -106,16 +106,26 @@ representation of LSP request JSON data."
 
 ;; More Rescript utility functions
 (defun lsp-rescript--create-interface-from-buffer (buffer)
+  "Get an implementation file created from the current BUFFER's file."
   (interactive "bFile containing implementation: ")
   (with-current-buffer buffer
     (let ((uri (concat "file://localhost" (buffer-file-name) )))
       (if (lsp-request "textDocument/createInterface"
                        (list
-                        :uri uri)
-                       )
+                        :uri uri))
           (find-file (concat (buffer-file-name) "i" ))
-        ())
-      )))
+        (lsp-response)))))
+
+(defun lsp-rescript--open-compiled-file-from-buffer (buffer)
+  "Get the compiled file from the current source BUFFER's file."
+  (interactive "bFile containing source: ")
+  (with-current-buffer buffer
+    (-if-let* ((uri (concat "file://localhost" (buffer-file-name)))
+               (response (lsp-request "textDocument/openCompiled" (list :uri uri)))
+               (compiled-uri-with-protocol (gethash "uri" response))
+               (compiled-uri (replace-regexp-in-string "file://" "" compiled-uri-with-protocol)))
+        (find-file compiled-uri)
+      (lsp-warn "Error finding compiled JS code!"))))
 
 
 (add-to-list 'lsp-language-id-configuration '(rescript-mode . "rescript"))


### PR DESCRIPTION
This PR adds support for additional LSP commands.

Most importantly, it adds support for creating an interface from an implementation, something sorely lacking in the emacs mode.

May not be perfectly idiomatic elisp and/or LSP code, but seems to do the job.